### PR TITLE
Mark as compatible with all upcoming major versions, including 2018.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ but the synchronisation feature is disabled in this case.
 ### Versions
 
 Versions **2016.3 or later** are supported.
-New major versions will be supported when they've been released.
 
 ### IDEs
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
     mavenCentral()
 }
 
-version = '1.0.0'
+version = '1.0.1'
 
 allprojects {
     apply plugin: 'java'
@@ -25,7 +25,7 @@ allprojects {
 
     patchPluginXml {
         sinceBuild '163.0'
-        untilBuild '173.*'
+        untilBuild '*.*'
     }
 
     publishPlugin {

--- a/idea-dev/META-INF/plugin.xml
+++ b/idea-dev/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>zato</id>
     <name>Zato hot deployment</name>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <vendor email="mail@zato.io" url="https://zato.io/docs/">Zato Source s.r.o.</vendor>
     <category>network</category>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>zato</id>
     <name>Zato hot-deployment</name>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <vendor email="pycharm@m.zato.io" url="https://zato.io/docs/?pycharm-plugin">Zato Source s.r.o.</vendor>
     <category>network</category>
 
@@ -11,7 +11,12 @@
 
     <change-notes><![CDATA[
         <html>
-          <b>1.0 - 2017-01-18</b>
+          <b>1.0.1 - 2018-01-18</b>
+          <ul>
+            <li>Add compatibility with 2018.1 and later</li>
+          </ul>
+
+          <b>1.0.0 - 2018-01-18</b>
           <ul>
             <li>Initial release</li>
           </ul>


### PR DESCRIPTION
@dsuch This PR adds compatibility with 2018.1 and later. The version is updated to 1.0.1 (patch version updated, no further changes).