### PR TITLE
Fixed URLs for Zato 3

### DIFF
--- a/src/main/java/io/zato/intellij/settings/ZatoServerConfig.java
+++ b/src/main/java/io/zato/intellij/settings/ZatoServerConfig.java
@@ -101,7 +101,7 @@ public class ZatoServerConfig {
         }
 
         url = StringUtil.trimEnd(url, "/");
-        return url + "/zato/ide-deploy";
+        return url + "/ide-deploy";
     }
 
     @Attribute("username")

--- a/src/main/java/io/zato/intellij/settings/ZatoServerConfig.java
+++ b/src/main/java/io/zato/intellij/settings/ZatoServerConfig.java
@@ -96,7 +96,7 @@ public class ZatoServerConfig {
     }
 
     public String getUploadUrl() {
-        if (url.contains("zato/ide-deploy")) {
+        if (url.contains("/ide-deploy")) {
             return url;
         }
 

--- a/src/test/java/io/zato/http/MockHttpServer.java
+++ b/src/test/java/io/zato/http/MockHttpServer.java
@@ -32,7 +32,7 @@ public class MockHttpServer extends NanoHTTPD {
     private String path;
 
     public MockHttpServer(String username, String password) {
-        this(23000, "/zato/ide-deploy", username, password);
+        this(23000, "/ide-deploy", username, password);
     }
 
     public MockHttpServer(int port, String path, String username, String password) {

--- a/src/test/java/io/zato/http/RemoteZatoHttpTest.java
+++ b/src/test/java/io/zato/http/RemoteZatoHttpTest.java
@@ -35,13 +35,13 @@ public class RemoteZatoHttpTest {
         Assert.assertEquals("Expected a successful connection", HttpStatus.SC_OK,
                 api.testConnection(newServerConfig("/", "username", "secret")).getStatusCode());
         Assert.assertEquals("Expected a successful connection", HttpStatus.SC_OK,
-                api.testConnection(newServerConfig("/zato/ide-deploy", "username", "secret")).getStatusCode());
+                api.testConnection(newServerConfig("/ide-deploy", "username", "secret")).getStatusCode());
 
         Assert.assertEquals("A request with an invalid path must fail", HttpStatus.SC_NOT_FOUND,
                 api.testConnection(newServerConfig("/invalid/path", "myUser", "secret")).getStatusCode());
 
         Assert.assertEquals("A request with an invalid credentials must fail", HttpStatus.SC_UNAUTHORIZED,
-                api.testConnection(newServerConfig("/zato/ide-deploy", null, null)).getStatusCode());
+                api.testConnection(newServerConfig("/ide-deploy", null, null)).getStatusCode());
     }
 
     @Test
@@ -49,13 +49,13 @@ public class RemoteZatoHttpTest {
         ZatoHttp api = new RemoteZatoHttp();
 
         Assert.assertTrue("Expected a successful upload",
-                api.upload(newServerConfig("/zato/ide-deploy", "username", "secret"), "my content", Paths.get("/myFile.py")).getStatusCode() == HttpStatus.SC_OK);
+                api.upload(newServerConfig("/ide-deploy", "username", "secret"), "my content", Paths.get("/myFile.py")).getStatusCode() == HttpStatus.SC_OK);
 
         Assert.assertFalse("An upload request with an invalid path must fail",
                 api.upload(newServerConfig("/invalid/path", "myUser", "secret"), "my content", Paths.get("/myFile.py")).getStatusCode() == HttpStatus.SC_OK);
 
         Assert.assertFalse("An upload request with an invalid credentials must fail",
-                api.upload(newServerConfig("/zato/ide-deploy", null, null), "my content", Paths.get("/myFile.py")).getStatusCode() == HttpStatus.SC_OK);
+                api.upload(newServerConfig("/ide-deploy", null, null), "my content", Paths.get("/myFile.py")).getStatusCode() == HttpStatus.SC_OK);
     }
 
     @NotNull

--- a/src/test/java/io/zato/intellij/settings/ZatoServerConfigTest.java
+++ b/src/test/java/io/zato/intellij/settings/ZatoServerConfigTest.java
@@ -11,16 +11,16 @@ public class ZatoServerConfigTest {
     public void uploadUrl() {
         ZatoServerConfig c = new ZatoServerConfig("dev", "http://www.example.com/", "user", "secret", true);
         Assert.assertEquals("http://www.example.com/", c.getUrl());
-        Assert.assertEquals("http://www.example.com/zato/ide-deploy", c.getUploadUrl());
+        Assert.assertEquals("http://www.example.com/ide-deploy", c.getUploadUrl());
 
         //no trailing /
         c = new ZatoServerConfig("dev", "http://www.example.com", "user", "secret", true);
         Assert.assertEquals("http://www.example.com", c.getUrl());
-        Assert.assertEquals("http://www.example.com/zato/ide-deploy", c.getUploadUrl());
+        Assert.assertEquals("http://www.example.com/ide-deploy", c.getUploadUrl());
 
         //path in url
-        c = new ZatoServerConfig("dev", "http://www.example.com/zato/ide-deploy", "user", "secret", true);
-        Assert.assertEquals("http://www.example.com/zato/ide-deploy", c.getUrl());
-        Assert.assertEquals("http://www.example.com/zato/ide-deploy", c.getUploadUrl());
+        c = new ZatoServerConfig("dev", "http://www.example.com/ide-deploy", "user", "secret", true);
+        Assert.assertEquals("http://www.example.com/ide-deploy", c.getUrl());
+        Assert.assertEquals("http://www.example.com/ide-deploy", c.getUploadUrl());
     }
 }


### PR DESCRIPTION
This closes https://github.com/zatosource/ide-pycharm/issues/2

I have built it locally with the included tests, installed it and it worked fine with a live Zato 3 system.